### PR TITLE
2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.0 – 2025-08-05
+### Added
+- Add reuse compliance (#23) @AndyScherzinger
+- HaRP support (Nextcloud 32+) (#35) @oleksandr-nc
+
+### Fixed
+- handle next_task network exceptions @kyteinsky
+- fix model switch to work without disable and re-enable (#32) @kyteinsky
+- report errors to app_api on enable (#60) @kyteinsky
+
+### Changed
+- pin gh action versions (#31) @kyteinsky
+- make docker builds reproducible (#46) @kyteinsky
+- update pip deps and remove dependabot (#61) @kyteinsky
+- use the HEAD commit timestamp instead of 0 in docker build (#62) @kyteinsky
+- Improve error handling in task processing (#65) @lukasdotcom
+- Implement feedback for better error handling (#66) @lukasdotcom
+- Bump support to NC 32 @kyteinsky
+
+
 ## 2.0.3 – 2024-08-23
 ### Fixed
 - handle next_task network exceptions @kyteinsky

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
 
 For installation steps and other details, see https://docs.nextcloud.com/server/latest/admin_manual/ai/app_translate2.html
 	]]></description>
-	<version>2.0.3</version>
+	<version>2.1.0</version>
 	<licence>MIT</licence>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>
@@ -23,13 +23,13 @@ For installation steps and other details, see https://docs.nextcloud.com/server/
 	<bugs>https://github.com/nextcloud/translate2/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/translate2</repository>
 	<dependencies>
-		<nextcloud min-version="30" max-version="31" />
+		<nextcloud min-version="30" max-version="32" />
 	</dependencies>
 	<external-app>
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud/translate2</image>
-			<image-tag>2.0.3</image-tag>
+			<image-tag>2.1.0</image-tag>
 		</docker-install>
 		<scopes>
 			<value>AI_PROVIDERS</value>


### PR DESCRIPTION
## 2.1.0 – 2025-08-05
### Added
- Add reuse compliance (#23) @AndyScherzinger
- HaRP support (Nextcloud 32+) (#35) @oleksandr-nc

### Fixed
- handle next_task network exceptions @kyteinsky
- fix model switch to work without disable and re-enable (#32) @kyteinsky
- report errors to app_api on enable (#60) @kyteinsky

### Changed
- pin gh action versions (#31) @kyteinsky
- make docker builds reproducible (#46) @kyteinsky
- update pip deps and remove dependabot (#61) @kyteinsky
- use the HEAD commit timestamp instead of 0 in docker build (#62) @kyteinsky
- Improve error handling in task processing (#65) @lukasdotcom
- Implement feedback for better error handling (#66) @lukasdotcom
- Bump support to NC 32 @kyteinsky
