### PR TITLE
2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.2.0 – 2025-10-06
+### Added
+- use the config.json from the persistent volume if persent (#70) @kyteinsky
+
+### Fixed
+- correct task id from the task object for error reporting (#69) @kyteinsky
+
+### Changed
+- set max decoding length to 10k by default (#69) @kyteinsky
+- bump max NC version to 33
+
+
 ## 2.1.0 – 2025-08-05
 ### Added
 - Add reuse compliance (#23) @AndyScherzinger

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
 
 For installation steps and other details, see https://docs.nextcloud.com/server/latest/admin_manual/ai/app_translate2.html
 	]]></description>
-	<version>2.1.0</version>
+	<version>2.2.0</version>
 	<licence>MIT</licence>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>
@@ -23,13 +23,13 @@ For installation steps and other details, see https://docs.nextcloud.com/server/
 	<bugs>https://github.com/nextcloud/translate2/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/translate2</repository>
 	<dependencies>
-		<nextcloud min-version="30" max-version="32" />
+		<nextcloud min-version="30" max-version="33" />
 	</dependencies>
 	<external-app>
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud/translate2</image>
-			<image-tag>2.1.0</image-tag>
+			<image-tag>2.2.0</image-tag>
 		</docker-install>
 		<scopes>
 			<value>AI_PROVIDERS</value>


### PR DESCRIPTION
## 2.2.0 – 2025-10-06
### Added
- use the config.json from the persistent volume if persent (#70) @kyteinsky

### Fixed
- correct task id from the task object for error reporting (#69) @kyteinsky

### Changed
- set max decoding length to 10k by default (#69) @kyteinsky
- bump max NC version to 33
