### PR TITLE
fix: use "detect_language" instead of "auto" for lang detection enum value

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -81,7 +81,7 @@ async def lifespan(_: FastAPI):
 APP_ID = "translate2"
 TASK_TYPE_ID = "core:text2text:translate"
 IDLE_POLLING_INTERVAL = config["idle_polling_interval"]
-DETECT_LANGUAGE = ShapeEnumValue(name="Detect Language", value="auto")
+DETECT_LANGUAGE = ShapeEnumValue(name="Detect Language", value="detect_language")
 APP = FastAPI(lifespan=lifespan)
 
 


### PR DESCRIPTION
To achieve consistency with integration_openai and integration_deepl's values.
And this should not break anything I suppose since in this app we don't validate the origin language.

The provider is unregistered and re-registered on upgrade so the new values should be picked up.